### PR TITLE
ci: fix deprecation of codecov-action

### DIFF
--- a/actions/php-coverage-codecov/action.yml
+++ b/actions/php-coverage-codecov/action.yml
@@ -36,4 +36,4 @@ runs:
     - name: Publish coverage report to Codecov
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml


### PR DESCRIPTION
https://github.com/codecov/codecov-action?tab=readme-ov-file#migration-guide

You can see an example for the warning here
https://github.com/zenstruck/messenger-monitor-bundle/actions/runs/19809152561